### PR TITLE
fix: regex for short and long key names to allow dots and hyphens #3

### DIFF
--- a/CommandLineParser.Tests/MiscTests.cs
+++ b/CommandLineParser.Tests/MiscTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CommandLineParser.Tests.Helpers;
+using CommandLineParser.Tests.Models;
+using CommandLineParser.Tests.Attributes;
+using Newtonsoft.Json;
+
+namespace CommandLineParser.Tests
+{
+    [TestClass]
+    public class MiscTests
+    {
+        [TestMethod]
+        [TestDescription("program --dataset=1 --runs=5 --switch-probability=0.7 --iterations 100 -o ../project/folder")]
+        public void Test_That_Long_Names_Work()
+        {
+            string[] args = CommandManager.CommandLineToArgs("program --dataset=1 --runs=5 --switch-probability=0.7 --iterations 100 -o ../project/folder");
+            CommandParser parser = new CommandParser(args);
+            Console.WriteLine(JsonConvert.SerializeObject(parser.GetDictionary()));
+            var model = parser.Parse<MiscTestModel>();
+            Assert.AreEqual(1, model.Dataset);
+            Assert.AreEqual(5, model.Runs);
+            Assert.AreEqual(0.7, model.SwitchProbability);
+            Assert.AreEqual(100, model.NoOfIterations);
+            Assert.AreEqual("../project/folder", model.Output);
+        }
+        [TestMethod]
+        [TestDescription("program -d=1 -r=5 -x=0.7 -i 100 --output ../project/folder")]
+        public void Test_That_Short_Names_Work()
+        {
+            string[] args = CommandManager.CommandLineToArgs("program -d=1 -r=5 -x=0.7 -i 100 --output ../project/folder");
+            CommandParser parser = new CommandParser(args);
+            Console.WriteLine(JsonConvert.SerializeObject(parser.GetDictionary()));
+            var model = parser.Parse<MiscTestModel>();
+            Assert.AreEqual(1, model.Dataset);
+            Assert.AreEqual(5, model.Runs);
+            Assert.AreEqual(0.7, model.SwitchProbability);
+            Assert.AreEqual(100, model.NoOfIterations);
+            Assert.AreEqual("../project/folder", model.Output);
+        }
+    }
+}

--- a/CommandLineParser.Tests/Models/MiscTestModel.cs
+++ b/CommandLineParser.Tests/Models/MiscTestModel.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommandLineParser.Attributes;
+using Newtonsoft.Json;
+
+namespace CommandLineParser.Tests.Models
+{
+    [Help("== This is a Test Model ==")]
+    public class MiscTestModel: IConfigModel
+    {
+        [Flag("dataset", "d")]
+        public int Dataset { get; set; }
+
+        [Flag("runs", "r")]
+        public int Runs { get; set; }
+
+        [Flag("switch-probability", "x")]
+        public double SwitchProbability { get; set; }
+
+        [Flag("iterations", "i")]
+        public int NoOfIterations { get; set; }
+
+        [Flag("output", "o")]
+        public string Output { get; set; }
+
+        public string[] Extras { get; set; }
+        public string[] Options { get; set; }
+    }
+}

--- a/CommandLineParser/CommandParser.cs
+++ b/CommandLineParser/CommandParser.cs
@@ -95,7 +95,10 @@ namespace CommandLineParser
                 else //non-option
                 {
                     if (key == "" && !ret.ContainsKey(key)) ret.Add(key, new List<string>()); //options
-                    else ret[key].Add(arg);
+                    else {
+                        if (ret.ContainsKey(key)) ret[key].Add(arg);
+                        else ret.Add(key, new List<string>() { arg });
+                    }
                 }
             }
             return ret;
@@ -176,6 +179,9 @@ namespace CommandLineParser
                     break;
                 case "DateTime":
                     try { property.SetValue(ret, Convert.ToDateTime(flagValue)); } catch { throw new Exception($"Could not convert argument value of \"{flagValue}\" to DateTime"); }
+                    break;
+                case "Double":
+                    try { property.SetValue(ret, Convert.ToDouble(flagValue)); } catch { throw new Exception($"Could not convert argument value of \"{flagValue}\" to Double"); }
                     break;
                 case "Boolean":
                     Console.WriteLine("Boolean Found");

--- a/CommandLineParser/Helpers/KeyDetection.cs
+++ b/CommandLineParser/Helpers/KeyDetection.cs
@@ -10,8 +10,8 @@ namespace CommandLineParser.Helpers
     public class KeyDetection
     {
         public const string HELP_KEY_REGEX = @"^(--help)|(-h)|(-\?)|(\\\?)$";
-        public const string SHORT_KEY_REGEX = @"^-([a-zA-Z])(\w*)((\=)?\w+)?$";
-        public const string LONG_KEY_REGEX = @"^--[a-z]+(=(\w)+)?$";
+        public const string SHORT_KEY_REGEX = @"^-([a-zA-Z])(\w*)(=([a-zA-Z0-9\.])+)?$";
+        public const string LONG_KEY_REGEX = @"^--[a-z][a-z]*(-?([a-z]+))(=([a-zA-Z0-9\.])+)?$";
         private static ShortKeyDetection _shortDetector;
         private static LongKeyDetection _longDetector;
 
@@ -29,7 +29,7 @@ namespace CommandLineParser.Helpers
 
         public class ShortKeyDetection
         {
-            private const string KEY_JOINS_VALUE_REGEX = @"=\w+$"; //-u=name
+            private const string KEY_JOINS_VALUE_REGEX = @"(=([a-zA-Z0-9\.])+)$"; //-u=name
             public bool IsKey(string potentialKey)
             {
                 return Regex.IsMatch(potentialKey, KeyDetection.SHORT_KEY_REGEX);
@@ -83,7 +83,7 @@ namespace CommandLineParser.Helpers
 
         public class LongKeyDetection
         {
-            private const string KEY_JOINS_VALUE_REGEX = @"=\w+$"; //--user=name
+            private const string KEY_JOINS_VALUE_REGEX = @"=([a-zA-Z0-9\.])+$"; //--user=name
             public bool IsKey(string potentialKey)
             {
                 return Regex.IsMatch(potentialKey, KeyDetection.LONG_KEY_REGEX);


### PR DESCRIPTION
fix #3 